### PR TITLE
[FIX] Fix the click on the `reset` button when the happy path is not shown

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -20,7 +20,7 @@ export function configureButtons(bpmnVisualization) {
 class RuleButton {
     constructor(id, showCallback, hideCallback) {
         this.button = document.getElementById(id);
-        this.state = false;
+        this.dataAreShowed = false;
         this.showCallback = showCallback;
         this.hideCallback = hideCallback;
 
@@ -28,18 +28,18 @@ class RuleButton {
     }
 
     addEventListenerOnClick() {
-        this.button.addEventListener("click", () => !this.state ? this.show() : this.hide());
+        this.button.addEventListener("click", () => this.dataAreShowed ? this.hide() : this.show());
     }
 
     show() {
         this.showCallback();
         this.button.innerHTML = this.button.innerHTML.replace('Show', 'Hide');
-        this.state = true;
+        this.dataAreShowed = true;
     }
 
     hide() {
         this.hideCallback();
         this.button.innerHTML = this.button.innerHTML.replace('Hide', 'Show');
-        this.state = false;
+        this.dataAreShowed = false;
     }
 }

--- a/src/buttons.js
+++ b/src/buttons.js
@@ -32,14 +32,18 @@ class RuleButton {
     }
 
     show() {
-        this.showCallback();
-        this.button.innerHTML = this.button.innerHTML.replace('Show', 'Hide');
-        this.dataAreShowed = true;
+        if(!this.dataAreShowed) {
+            this.showCallback();
+            this.button.innerHTML = this.button.innerHTML.replace('Show', 'Hide');
+            this.dataAreShowed = true;
+        }
     }
 
     hide() {
-        this.hideCallback();
-        this.button.innerHTML = this.button.innerHTML.replace('Hide', 'Show');
-        this.dataAreShowed = false;
+        if(this.dataAreShowed) {
+            this.hideCallback();
+            this.button.innerHTML = this.button.innerHTML.replace('Hide', 'Show');
+            this.dataAreShowed = false;
+        }
     }
 }


### PR DESCRIPTION
### With the current version

https://user-images.githubusercontent.com/4921914/196987997-6eb50d03-370f-48ac-b11c-600995771ade.mov

When we click on the `reset` button and data other than happy path are displayed, nothing happens and we have an error on the console:
```
Uncaught TypeError: i is null
    hideHappyPath https://process-analytics.github.io/icpm-demo-2022/assets/index.9b55589f.js:321
    hideHappyPath https://process-analytics.github.io/icpm-demo-2022/assets/index.9b55589f.js:321
    e https://process-analytics.github.io/icpm-demo-2022/assets/index.9b55589f.js:354
    hide https://process-analytics.github.io/icpm-demo-2022/assets/index.9b55589f.js:354
    configureButtons https://process-analytics.github.io/icpm-demo-2022/assets/index.9b55589f.js:354
```

### With the fix

https://user-images.githubusercontent.com/4921914/196988894-5540a77e-6222-4285-bc08-e73dfcb383eb.mov

