### PR TITLE
chore: deploy PR preview to Surge

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,22 @@
+name: 'Build'
+description: 'Setup node, install dependencies and build'
+inputs:
+  npm-script:
+    description: 'The name of the npm script to run.'
+    required: false
+    default: 'build'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+        cache: "npm"
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+    - name: Build
+      shell: bash
+      run: npm run ${{ inputs.npm-script }}

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -5,7 +5,14 @@ on:
   # Triggers the workflow on push event but only for the "main" branch
   push:
     branches: [ "main" ]
-
+    paths:
+      - '.github/actions/build/**/*'
+      - '.github/workflows/deploy-demo.yml'
+      - 'src/**/*'
+      - '.nvmrc'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -24,20 +24,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Build
-        run: npm run build
+        uses: ./.github/actions/build
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build
-
+        # NOT THE SAME AS IN THE deployment production WF
+        run: npm run build-for-surge
       - uses: bonitasoft/actions/packages/surge-preview-tools@v1
         id: surge-preview-tools
         with:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,57 @@
+name: Deploy PR preview
+
+on:
+  pull_request:
+    # To manage 'surge-preview' action teardown, add default event types + closed event type
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
+    paths:
+      - '.github/workflows/deploy-pr-preview.yml'
+      - 'config/**/*'
+      - 'dev/**/*'
+      - 'src/**/*'
+      - '.nvmrc'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  demo_preview: # keep unique across jobs using surge preview (preview url and PR comment id)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # surge-preview: PR comments
+    steps:
+      - uses: actions/checkout@v3
+# TODO duplication with the other workflow
+#      - name: Build Setup
+#        uses: ./.github/actions/build-setup
+#        if: github.event.action != 'closed'
+
+# TODO run only if not closed
+#         if: github.event.action != 'closed'
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+
+      - uses: bonitasoft/actions/packages/surge-preview-tools@v1
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN }}
+
+      - name: Manage surge preview
+        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
+        uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: './dist'
+          failOnError: true
+          teardown: 'true'
+          build: echo 'already built!'

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -30,6 +30,10 @@ jobs:
         if: github.event.action != 'closed'
         with:
           npm-script: 'build-for-surge'
+      - uses: bonitasoft/actions/packages/surge-preview-tools@v1
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN }}
       - name: Manage surge preview
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         uses: afc163/surge-preview@v1

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -9,8 +9,6 @@ on:
     paths:
       - '.github/actions/build/**/*'
       - '.github/workflows/deploy-pr-preview.yml'
-      - 'config/**/*'
-      - 'dev/**/*'
       - 'src/**/*'
       - '.nvmrc'
       - 'index.html'
@@ -24,7 +22,6 @@ jobs:
       pull-requests: write # surge-preview: PR comments
     steps:
       - uses: actions/checkout@v3
-# TODO use the shared action in the other workflow
       - name: Build
         uses: ./.github/actions/build
         if: github.event.action != 'closed'

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/actions/build/**/*'
       - '.github/workflows/deploy-pr-preview.yml'
       - 'config/**/*'
       - 'dev/**/*'
@@ -23,28 +24,12 @@ jobs:
       pull-requests: write # surge-preview: PR comments
     steps:
       - uses: actions/checkout@v3
-# TODO duplication with the other workflow
-#      - name: Build Setup
-#        uses: ./.github/actions/build-setup
-#        if: github.event.action != 'closed'
-
-# TODO run only if not closed
-#         if: github.event.action != 'closed'
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
+# TODO use the shared action in the other workflow
       - name: Build
-        # NOT THE SAME AS IN THE deployment production WF
-        run: npm run build-for-surge
-      - uses: bonitasoft/actions/packages/surge-preview-tools@v1
-        id: surge-preview-tools
+        uses: ./.github/actions/build
+        if: github.event.action != 'closed'
         with:
-          surge-token: ${{ secrets.SURGE_TOKEN }}
-
+          npm-script: 'build-for-surge'
       - name: Manage surge preview
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         uses: afc163/surge-preview@v1

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "vite",
     "build": "vite build --base=/icpm-demo-2022/",
-    "preview": "vite preview --base /icpm-demo-2022/ --open"
+    "preview": "vite preview --base /icpm-demo-2022/ --open",
+    "build-for-surge": "vite build"
   },
   "dependencies": {
     "animejs": "3.2.1",


### PR DESCRIPTION
Introduce a GitHub workflow to deploy to Surge, as we do in other repositories of the organization.
To avoid duplication, also introduce a local action to build the application and use it in all workflows where possible.

### Notes for reviewers

It is not possible to test the 'deploy demo' workflow except by changing the GitHub Pages configuration. I didn't test it but I am pretty confident with the changes. Please have a special look at it while reviewing.
