### PR TITLE
chore: ensure Pull Request title follows "conventional commits"

### DIFF
--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check-pr-title:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # conventional-commits-pr-action: PR comments
     steps:
       - name: Check pull request title
         uses: jef/conventional-commits-pr-action@v1

--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,16 @@
+name: Check Pull Request Metadata
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check pull request title
+        uses: jef/conventional-commits-pr-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment: true # Post a comment in the pull request conversation with examples.


### PR DESCRIPTION
closes #35

### Rationale

"conventional commits" is a shared practice (https://www.conventionalcommits.org/en/v1.0.0/) and a lot of people are following it.
Historically, in PA repositories, we use a custom pattern that is derived from the prefix we use to qualify issues: [FIX], [FEAT], [INFRA], ... (notice that issues use BUG while PR use FIX).
As this is custom, even if we document the pattern in the PR Template, external contributors are not following it when they write the PR title and often use "conventional commits" (like in https://github.com/process-analytics/bpmn-visualization-R/pull/117), their own convention or no convention (free style text).

Remember that we use the PR title to create the squash commit to the main branch, so PR title must be consistent.

Enforcing the PR title with a GH workflow ensures that we detect PR titles using a wrong syntax. The GH action used here provides guidance when the title doesn't follow "conventional commits" by creating a PR comment explaining the problem and resolution tips. When the title is correct, the comment is removed keeping the PR timeline cleaned.

This action has already be setup in other repositories of the organization and I would like to generalize that
- https://github.com/process-analytics/bpmn-visualization-tools/pull/3 
- https://github.com/process-analytics/.github/pull/14 