### PR TITLE
refactor: remove unused MutationObserver code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,26 +33,3 @@ configureButtons(mainBpmnVisualization);
 const footer = document.querySelector("footer");
 const version = mainBpmnVisualization.getVersion();
 footer.innerText = `bpmn-visualization@${version.lib}`;
-
-
-/*TO BE IMPLEMENTED
-observe navigation and zooming and
-update circle ripples and linearGradient if they were added*/
-
-var containerBpmn = document.querySelector("#main-bpmn-container");
-
-var containerObserver = new MutationObserver(function (mutations) {
-  mutations.forEach(function (mutation) {
-    if (mutation.type === "attributes") {
-      //check if ripple circles exist
-      //if yes, recall ripple function
-      //check if Gradient exists
-      //if yes, re-add them
-    }
-  });
-});
-
-containerObserver.observe(containerBpmn, {
-  attributes: true, //configure it to listen to attribute changes
-  attributeFilter: ["min-width", "min-height"] // filter your attributes
-});


### PR DESCRIPTION
This was a start for an implementation that was supposed to fix the remove of custom additions in the SVG nodes. They were removed when doing diagram navigation. This implementation was not finished and as we are removing the diagram navigation there is no need for such fixes.

fixes #33 