### PR TITLE
fix: ensure all edges are visually attached to shapes in the main BPMN diagram

### DIFF
--- a/src/diagrams/EC-purchase-orders-collapsed.bpmn
+++ b/src/diagrams/EC-purchase-orders-collapsed.bpmn
@@ -151,7 +151,7 @@
         <omgdi:waypoint x="885" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19cdedl_di" bpmnElement="Flow_19cdedl">
-        <omgdi:waypoint x="880" y="210" />
+        <omgdi:waypoint x="875" y="210" />
         <omgdi:waypoint x="910" y="210" />
         <omgdi:waypoint x="910" y="345" />
       </bpmndi:BPMNEdge>


### PR DESCRIPTION
Review the waypoints to have the terminal points on the perimeter of the shapes they link.

fixes #68

### Notes

before | now
----- | -----
![image](https://user-images.githubusercontent.com/27200110/197457810-c88c705c-c68c-4b5d-87bb-2d5d219a6913.png) | ![image](https://user-images.githubusercontent.com/27200110/197533171-8d84948d-d690-446d-9aca-d8fce2cd8616.png)
