### PR TITLE
fix(happy-path): make the overlay fully visible

### DIFF
--- a/src/happy-path.js
+++ b/src/happy-path.js
@@ -108,17 +108,15 @@ export function showHappyPath(bpmnVisualization) {
 
   bpmnVisualization.bpmnElementsRegistry.addOverlays(
       happyPathElementWithOverlays,
-      [
-        {
-          position: "top-left",
-          label: "45 traces \n (7.36%) \n ⏳ 2.08 months",
-          style: {
-            font: { color: "green", size: 14 },
-            fill: { color: "White", opacity: 40 },
-            stroke: { color: "black", width: 0 },
-          },
+      {
+        position: "top-center",
+        label: "45 traces \n (7.36%) \n ⏳ 2.08 months",
+        style: {
+          font: {color: "green", size: 14},
+          fill: {color: "White", opacity: 40},
+          stroke: {color: "black", width: 0},
         },
-      ]
+      }
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const mainBpmnVisualization = new BpmnVisualization({
 
 // Load BPMN diagram
 // Try the "Center" type to fit the whole container and center the diagram
-mainBpmnVisualization.load(collapsedDiagram, { fit: { type: FitType.Center, margin: 10 } });
+mainBpmnVisualization.load(collapsedDiagram, { fit: { type: FitType.Center, margin: 20 } });
 
 
 // Interaction


### PR DESCRIPTION
The left part of the overlay was hidden. It is now centered on the start event and visible by adding a margin when fitting to leave more spaces on the left of the start event.

covers #45

### Screenshots

before | now
---- | ----
![image](https://user-images.githubusercontent.com/27200110/198046451-e0ef0049-f3e6-4be5-95be-f218c6847bb8.png) | ![image](https://user-images.githubusercontent.com/27200110/198046823-94b07acd-b4d8-43d9-a7cb-b13f786e26c3.png)
