### PR TITLE
chore: clean the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "icpm-demo-2022",
   "private": true,
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.html",
+  "version": "0.0.0",
   "scripts": {
     "start": "vite",
     "build": "vite build --base=/icpm-demo-2022/",
@@ -17,6 +15,5 @@
   },
   "devDependencies": {
     "vite": "~3.1.8"
-  },
-  "keywords": []
+  }
 }


### PR DESCRIPTION
Remove the following attributes
  - version: we are not publishing the demo on npmjs and we don't want to maintain this field
  - main: no publishing, so no consumption. The previous value wasn't accurate (index.html whereas this attribute must store the name of a CommonJS file)
  - empty attributes (description, keywords)