### PR TITLE
chore: simplify the "build" commands

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,10 +1,5 @@
 name: 'Build'
 description: 'Setup node, install dependencies and build'
-inputs:
-  npm-script:
-    description: 'The name of the npm script to run.'
-    required: false
-    default: 'build'
 
 runs:
   using: 'composite'
@@ -19,4 +14,4 @@ runs:
       run: npm ci
     - name: Build
       shell: bash
-      run: npm run ${{ inputs.npm-script }}
+      run: npm run build

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         if: github.event.action != 'closed'
-        with:
-          npm-script: 'build-for-surge'
       - uses: bonitasoft/actions/packages/surge-preview-tools@v1
         id: surge-preview-tools
         with:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "version": "0.0.0",
   "scripts": {
     "start": "vite",
-    "build": "vite build --base=/icpm-demo-2022/",
-    "preview": "vite preview --base /icpm-demo-2022/ --open",
-    "build-for-surge": "vite build"
+    "build": "vite build --base ./",
+    "preview": "vite preview --base ./ --open",
   },
   "dependencies": {
     "bpmn-visualization": "0.27.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "vite",
     "build": "vite build --base ./",
-    "preview": "vite preview --base ./ --open",
+    "preview": "vite preview --base ./ --open"
   },
   "dependencies": {
     "bpmn-visualization": "0.27.1",


### PR DESCRIPTION
Use a relative build path to be able to deploy in any context (local, surge, GitHub Pages, ....)Use a relative build path to be able to deploy in any context (local, surge, GitHub Pages, ....)

### Notes

Use the same configuration for the vite build command as we do in https://github.com/process-analytics/bpmn-visualization-demo-template