### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    versioning-strategy: increase
+    rebase-strategy: "disabled"
+    allow:
+      - dependency-type: "production"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - javascript
+    reviewers:
+      - process-analytics/pa-collaborators
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    rebase-strategy: "disabled"
+    commit-message:
+      prefix: "chore(gha)"
+    labels:
+      - dependencies
+      - github_actions
+      - skip-changelog
+    reviewers:
+      - process-analytics/pa-collaborators


### PR DESCRIPTION
Update npm production dependencies and GitHub Actions

### Notes

Same configuration as in https://github.com/process-analytics/bpmn-visualization-demo-template